### PR TITLE
fix: turn off tsup bundle to resolve an issue with js builds

### DIFF
--- a/.changeset/ripe-beans-wish.md
+++ b/.changeset/ripe-beans-wish.md
@@ -1,0 +1,8 @@
+---
+"@sophon-labs/account-eip6963": patch
+"@sophon-labs/account-react": patch
+"@sophon-labs/account-wagmi": patch
+"@sophon-labs/account-core": patch
+---
+
+chore: turn off the bundle: false tsup config option that breaks js builds

--- a/packages/account-core/tsup.config.ts
+++ b/packages/account-core/tsup.config.ts
@@ -17,7 +17,6 @@ export default defineConfig((options) => {
     splitting: true,
     sourcemap: !!options.watch,
     clean: true,
-    bundle: false,
     minify: !options.watch,
     dts: true,
     format: ["esm", "cjs"],

--- a/packages/account-eip6963/tsup.config.ts
+++ b/packages/account-eip6963/tsup.config.ts
@@ -12,7 +12,6 @@ export default defineConfig((options) => {
     splitting: true,
     sourcemap: !!options.watch,
     clean: true,
-    bundle: false,
     minify: !options.watch,
     dts: true,
     format: ["esm", "cjs"],

--- a/packages/account-react/tsup.config.ts
+++ b/packages/account-react/tsup.config.ts
@@ -5,7 +5,6 @@ export default defineConfig((options) => {
   return {
     entry: ["src/*", "src/hooks/*", "src/components/*"],
     splitting: true,
-    bundle: false,
     sourcemap: !!options.watch,
     clean: true,
     minify: !options.watch,

--- a/packages/account-wagmi/tsup.config.ts
+++ b/packages/account-wagmi/tsup.config.ts
@@ -5,7 +5,6 @@ export default defineConfig((options) => {
   return {
     entry: ["src/*", "src/hooks/*", "src/components/*"],
     splitting: true,
-    bundle: false,
     sourcemap: !!options.watch,
     clean: true,
     minify: !options.watch,


### PR DESCRIPTION
The `bundle` option in tsup is unfortunately broken, you can read more about it here: https://github.com/egoist/tsup/issues/953 

If you enable the option, anyone who's using the `"type": "module"` in their `package.json` will experience an error that looks somewhat like this:

```
Cannot find module './node_modules/@sophon-labs/account-eip6963/dist/emitter' imported from ./node_modules/@sophon-labs/account-eip6963/dist/testnet.js"
```

The error states that it's looking for `dist/emitter` but cannot find it - that's correct, because it doesn't exist. It needs to import `dist/emitter.js`, as that's the file that actually exists on the disk (so including the .js extension)

There are a few ways to resolve this, one of which is to simply unset the `bundle` option.

If you're really keen on using the `bundle: true` option, there are alternative suggestions made in the Github issue I linked at the beginning, but I'm honestly not sure if it benefits the bundle size that much. 