### PR TITLE
feat: add changeset workflows

### DIFF
--- a/.github/actions/pnpm-install/action.yml
+++ b/.github/actions/pnpm-install/action.yml
@@ -1,0 +1,87 @@
+########################################################################################
+# "pnpm install" composite action for pnpm 7/8+                                        #
+#--------------------------------------------------------------------------------------#
+# Requirement: @setup/node should be run before                                        #
+#                                                                                      #
+# Usage in workflows steps:                                                            #
+#                                                                                      #
+#      - name: 📥 Monorepo install                                                     #
+#        uses: ./.github/actions/pnpm-install                                          #
+#        with:                                                                         #
+#          enable-corepack: false # (default)                                          #
+#          cwd: ${{ github.workspace }}/apps/my-app # (default = '.')                  #
+#                                                                                      #
+# Reference:                                                                           #
+#   - latest: https://gist.github.com/belgattitude/838b2eba30c324f1f0033a797bab2e31    #
+#                                                                                      #
+# Versions:                                                                            #
+#   - 1.1.0 - 15-07-2023 - Add project custom directory support.                       #
+########################################################################################
+
+
+name: 'PNPM install'
+description: 'Run pnpm install with cache enabled'
+
+inputs:
+  enable-corepack:
+    description: 'Enable corepack'
+    required: false
+    default: 'false'
+  cwd:
+    description: "Changes node's process.cwd() if the project is not located on the root. Default to process.cwd()"
+    required: false
+    default: '.'
+
+runs:
+  using: 'composite'
+
+  steps:
+    - name: ⚙️ Enable Corepack
+      if: ${{ inputs.enable-corepack == 'true' }}
+      shell: bash
+      working-directory: ${{ inputs.cwd }}
+      run: |
+        corepack enable
+        echo "corepack enabled"
+
+    - uses: pnpm/action-setup@v4
+      if: ${{ inputs.enable-corepack == 'false' }}
+      with:
+        run_install: false
+        # If you're not setting the packageManager field in package.json, add the version here
+        # version: 8.7.0
+
+    - name: Expose pnpm config(s) through "$GITHUB_OUTPUT"
+      id: pnpm-config
+      shell: bash
+      run: |
+        echo "STORE_PATH=$(pnpm store path | tr -d '\n')" >> $GITHUB_OUTPUT
+
+    - name: Cache rotation keys
+      id: cache-rotation
+      shell: bash
+      run: |
+        echo "YEAR_MONTH=$(/bin/date -u "+%Y%m")" >> $GITHUB_OUTPUT
+
+    - uses: actions/cache@v3
+      name: Setup pnpm cache
+      with:
+        path: ${{ steps.pnpm-config.outputs.STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-store-cache-${{ steps.cache-rotation.outputs.YEAR_MONTH }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-cache-${{ steps.cache-rotation.outputs.YEAR_MONTH }}-
+
+    # Prevent store to grow over time (not needed with yarn)
+    # Note: not perfect as it prune too much in monorepos so the idea
+    #       is to use cache-rotation as above. In the future this might work better.
+    #- name: Prune pnpm store
+    #  shell: bash
+    #  run: pnpm prune store
+
+    - name: Install dependencies
+      shell: bash
+      working-directory: ${{ inputs.cwd }}
+      run: pnpm install --frozen-lockfile --prefer-offline
+      env:
+        # Other environment variables
+        HUSKY: '0' # By default do not run HUSKY install

--- a/.github/workflows/package-publication.yml
+++ b/.github/workflows/package-publication.yml
@@ -1,0 +1,45 @@
+name: 'Release @sophon-labs/* account packages'
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish-packages:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: 📥 dependency installation
+        uses: ./.github/actions/pnpm-install
+
+      # Build the packages
+      - name: Build the packages
+        run: build:core
+
+      # Set-up the .npmrc to authenticate with the npm registry
+      - name: Setup npmrc
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+
+      # Publish packages to npm
+      - name: 🚀 Create packages and publish in the npm registry
+        uses: changesets/action@v1
+        with:
+          commit: "release: @sophon-labs account packages"
+          title: "release: @sophon-labs account packages"
+          version: pnpm release:version
+          publish: pnpm release:publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-account-core.yml
+++ b/.github/workflows/test-account-core.yml
@@ -1,6 +1,7 @@
 name: Test Account Core Package
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - "packages/account-core/**"
@@ -19,28 +20,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v3
         with:
-          node-version: "22"
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.2.1
+      - name: 📥 dependency installation
+        uses: ./.github/actions/pnpm-install
 
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+      # Build the packages
+      - name: Build the packages
+        run: build:core
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "build:core": "pnpm run --stream -r --filter @sophon-labs/account-core --filter @sophon-labs/account-wagmi --filter @sophon-labs/account-eip6963 --filter @sophon-labs/account-react --filter sophon-ui build",
     "dev:core": "pnpm run --stream --parallel -r --filter @sophon-labs/account-core --filter @sophon-labs/account-wagmi --filter @sophon-labs/account-eip6963 --filter @sophon-labs/account-react dev ",
     "lint": "eslint .",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "release:generate": "changeset",
+    "release:version": "changeset version",
+    "release:publish": "pnpm publish -r --no-git-checks"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
I've added a workflow we're using in our team to publish packages onto npm with ease. There's only one step to take: someone on the Sophon side needs to create an npm access token that's permitted to the `@sophon-labs` write scope.

Once created, simply add that token to the repository secrets with a secret named: `NPM_TOKEN`.

If you merge any commit to main with a changeset, it will open a release PR. Every new commit to main with every new changeset will flow into the release PR, and once you're happy to publish all the changes you can simply merge the release PR.